### PR TITLE
Build python3-sigrok

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libsigrok (0.5.2-3+wb102) stable; urgency=medium
+
+  * Build python3-sigrok
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 29 Aug 2025 18:10:00 +0400
+
 libsigrok (0.5.2-3+wb101) stable; urgency=medium
 
   * Enhanced Support for OWON XDM Series DMMs: Range Management and XDM1241 Integration

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Maintainer: Debian Electronics Packaging Team <pkg-electronics-devel@alioth-list
 Uploaders: Jonathan McDowell <noodles@earth.li>
 Build-Depends: check,
 	debhelper (>= 10),
+	dh-python,
 	doxygen,
 	libbluetooth-dev,
 	libftdi1-dev,
@@ -14,7 +15,11 @@ Build-Depends: check,
 	libserialport-dev (>= 0.1.0),
 	libusb-1.0-0-dev (>= 1.0.16),
 	libzip-dev (>= 0.10),
-	pkg-config (>= 0.22)
+	pkg-config (>= 0.22),
+	python3-dev,
+	python3-numpy,
+	python-gi-dev,
+	swig
 Standards-Version: 4.5.0
 Section: libs
 Homepage: http://sigrok.org/wiki/Libsigrok
@@ -77,3 +82,9 @@ Description: sigrok hardware driver library - shared library
  .
  This package contains the C++ shared library.
 
+Package: python3-sigrok
+Section: python
+Architecture: any
+Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
+Description: libsigrok Python 3 bindings
+ This package contains the Python 3 bindings for the library.

--- a/debian/control
+++ b/debian/control
@@ -85,6 +85,6 @@ Description: sigrok hardware driver library - shared library
 Package: python3-sigrok
 Section: python
 Architecture: any
-Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
+Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}, python3-numpy
 Description: libsigrok Python 3 bindings
  This package contains the Python 3 bindings for the library.

--- a/debian/python3-sigrok.install
+++ b/debian/python3-sigrok.install
@@ -1,0 +1,1 @@
+usr/lib/python3*/

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 %:
-	dh $@
+	dh $@ --with=python3
 
 override_dh_auto_install:
 	mkdir -p debian/tmp/lib/udev/rules.d


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавляет сборку биндинга для питона.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
```python
>>> import sigrok.core as sr
>>> sr.Context.create()
<sigrok.core.classes.Context; proxy of <Swig Object of type 'std::shared_ptr< sigrok::Context > *' at 0xb6830d88> >
```

