### PR TITLE
Feature/add support for sr t mq type to python bindings

### DIFF
--- a/bindings/python/sigrok/core/classes.i
+++ b/bindings/python/sigrok/core/classes.i
@@ -350,6 +350,18 @@ Glib::VariantBase python_to_variant_by_key(PyObject *input, const sigrok::Config
           return Glib::Variant< std::vector<guint64> >::create(v);
         }
     }
+    else if ((type == SR_T_MQ) && PyTuple_Check(input) && (PyTuple_Size(input) == 2)) {
+        PyObject *numObj = PyTuple_GetItem(input, 0);
+        PyObject *denomObj = PyTuple_GetItem(input, 1);
+        if ((PyInt_Check(numObj) || PyLong_Check(numObj)) && (PyInt_Check(denomObj) || PyLong_Check(denomObj))) {
+            return Glib::Variant<std::tuple<guint32, guint64>>::create(
+                std::make_tuple(
+                    (guint32)PyInt_AsLong(numObj),
+                    (guint64)PyInt_AsLong(denomObj)
+                )
+            );
+        }
+    }
     throw sigrok::Error(SR_ERR_ARG);
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libsigrok (0.5.2-3+wb103) stable; urgency=medium
+
+  * Add support for SR_T_MQ type in Python bindings
+
+ -- Vladimir Zuevskiy <vladimir.zuevskiy@wirenboard.com>  Fri, 05 Sep 2025 17:42:27 +0300
+
 libsigrok (0.5.2-3+wb102) stable; urgency=medium
 
   * Build python3-sigrok


### PR DESCRIPTION
Добавил поддержку типа `SR_T_MQ` в python bindings.

Без этих правок нельзя поменять режим работы owon xdm1041 используя python bindings  (режим задается кортежем из двух целых чисел). Да и вообще, проблема актуальна для любых других устройств, где нужно задать параметры типа `SR_T_MQ`. Связано с тем, что [тут](https://github.com/wirenboard/libsigrok/blob/467431beee87028957ebd1312e346e0cfcdb6ec2/bindings/python/sigrok/core/classes.i#L327-L354) забыли про существование этого типа.


У owon 1041 возможные варианты режимов работы: 
```
(Pdb) device.config_list(sr.ConfigKey.MEASURED_QUANTITY)
[(10000, 1), (10000, 2), (10001, 1), (10001, 2), (10002, 0), (10007, 0), (10000, 10), (10004, 0), (10005, 0), (10015, 0), (10003, 0)]
```

До правок, если попытаться задать режим, было так:
```
Установка MEASURED_QUANTITY = (10000, 2)
Traceback (most recent call last):
  File "/opt/wb-test-suite-ng-vzuevskiy/./owon_clean.py", line 74, in <module>
    sys.exit(main())
  File "/opt/wb-test-suite-ng-vzuevskiy/./owon_clean.py", line 53, in main
    device.config_set(k, v)
  File "/usr/lib/python3/dist-packages/sigrok/core/classes.py", line 2452, in config_set
    return _classes.Configurable_config_set(self, *args)
ValueError: invalid argument

```

После внесения правок стало так:
```
Установка MEASURED_QUANTITY = (10000, 2)
sr: [00:01.110977] hwdriver: sr_config_set(): key 30047 (measured_quantity) sdi 0x419258 cg NULL -> (uint32 10000, uint64 2)
sr: [00:01.111810] serial: Wrote 13/13 bytes.
sr: [00:01.112370] scpi_serial: Successfully sent SCPI command: 'CONF:VOLT:DC'.
```

Ну и на приборе наглядно видно, что заработало
