### PR TITLE
scpi-dmm: add meas_rate option for OWON XDM1041, XDM1241, XDM2041

### DIFF
--- a/include/libsigrok/libsigrok.h
+++ b/include/libsigrok/libsigrok.h
@@ -1267,6 +1267,11 @@ enum sr_configkey {
 	 */
 	SR_CONF_GATE_TIME,
 
+	/**
+	 * measurement rate
+	 */
+    SR_CONF_MEAS_RATE,
+
 	/* Update sr_key_info_config[] (hwdriver.c) upon changes! */
 };
 

--- a/src/hardware/scpi-dmm/api.c
+++ b/src/hardware/scpi-dmm/api.c
@@ -48,6 +48,16 @@ static const uint32_t devopts_generic_range[] = {
 	SR_CONF_RANGE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
 };
 
+static const uint32_t devopts_owon_range[] = {
+	SR_CONF_CONTINUOUS,
+	SR_CONF_CONN | SR_CONF_GET,
+	SR_CONF_LIMIT_SAMPLES | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_LIMIT_MSEC | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_MEASURED_QUANTITY | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_RANGE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_MEAS_RATE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+};
+
 static const struct scpi_command cmdset_agilent[] = {
 	{ DMM_CMD_SETUP_REMOTE, "\n", },
 	{ DMM_CMD_SETUP_LOCAL, "SYST:LOC", },
@@ -126,6 +136,8 @@ static const struct scpi_command cmdset_owon[] = {
 	{ DMM_CMD_SETUP_RANGE, "CONF:%s %s", },
 	{ DMM_CMD_QUERY_RANGE, "RANGE?", },
 	{ DMM_CMD_QUERY_RANGE_AUTO, "AUTO?", },
+	{ DMM_CMD_SETUP_MEAS_RATE, "RATE %s", },
+ 	{ DMM_CMD_QUERY_MEAS_RATE, "RATE?", },
 	ALL_ZERO,
 };
 
@@ -189,11 +201,11 @@ static const struct mqopt_item mqopts_gwinstek_gdm906x[] = {
 };
 
 static const struct mqopt_item mqopts_owon_xdm1041[] = {
-	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT AC", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "CURR AC", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "CURR", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_RESISTANCE, 0, "RES", "RES", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT AC", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "CURR AC", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "CURR", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_RESISTANCE, 0, "RES", "RES", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
 	{ SR_MQ_CONTINUITY, 0, "CONT", "CONT", -1, FLAG_NO_RANGE, },
 	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC | SR_MQFLAG_DIODE, "DIOD", "DIOD", -4, FLAG_NO_RANGE, },
 	{ SR_MQ_TEMPERATURE, 0, "TEMP", "TEMP", NO_DFLT_PREC, FLAGS_NONE, },
@@ -203,12 +215,12 @@ static const struct mqopt_item mqopts_owon_xdm1041[] = {
 };
 
 static const struct mqopt_item mqopts_owon_xdm2041[] = {
-	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT AC", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "CURR AC", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "CURR", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_RESISTANCE, 0, "RES", "RES", NO_DFLT_PREC, FLAGS_NONE, },
-	{ SR_MQ_RESISTANCE, SR_MQFLAG_FOUR_WIRE, "FRES", "FRES", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT AC", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "CURR AC", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "CURR", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_RESISTANCE, 0, "RES", "RES", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
+	{ SR_MQ_RESISTANCE, SR_MQFLAG_FOUR_WIRE, "FRES", "FRES", NO_DFLT_PREC, FLAG_HAS_MEAS_RATE, },
 	{ SR_MQ_CONTINUITY, 0, "CONT", "CONT", -1, FLAG_NO_RANGE, },
 	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC | SR_MQFLAG_DIODE, "DIOD", "DIOD", -4, FLAG_NO_RANGE, },
 	{ SR_MQ_TEMPERATURE, 0, "TEMP", "TEMP", NO_DFLT_PREC, FLAGS_NONE, },
@@ -239,6 +251,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		ARRAY_AND_SIZE(devopts_generic_range),
 		0, 200 * 1000, 2500 * 1000, 0, FALSE,
 		scpi_dmm_get_range_text, scpi_dmm_set_range_from_text, NULL,
+		NULL, NULL, NULL,
 	},
 	{
 		"Agilent", "34410A",
@@ -246,6 +259,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		scpi_dmm_get_meas_agilent,
 		ARRAY_AND_SIZE(devopts_generic),
 		0, 0, 0, 0, FALSE,
+		NULL, NULL, NULL,
 		NULL, NULL, NULL,
 	},
 	{
@@ -255,6 +269,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		ARRAY_AND_SIZE(devopts_generic_range),
 		0, 0, 10 * 1000, 0, FALSE,
 		scpi_dmm_get_range_text, scpi_dmm_set_range_from_text, NULL,
+		NULL, NULL, NULL,
 	},
 	{
 		"GW", "GDM8251A",
@@ -262,6 +277,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		scpi_dmm_get_meas_gwinstek,
 		ARRAY_AND_SIZE(devopts_generic),
 		2500 * 1000, 0, 0, 0, FALSE,
+		NULL, NULL, NULL,
 		NULL, NULL, NULL,
 	},
 	{
@@ -271,6 +287,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		ARRAY_AND_SIZE(devopts_generic),
 		2500 * 1000, 0, 0, 0, FALSE,
 		NULL, NULL, NULL,
+		NULL, NULL, NULL,
 	},
 	{
 		"GWInstek", "GDM9060",
@@ -279,6 +296,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		ARRAY_AND_SIZE(devopts_generic),
 		0, 0, 0, 0, FALSE,
 		NULL, NULL, NULL,
+		NULL, NULL, NULL,
 	},
 	{
 		"GWInstek", "GDM9061",
@@ -286,6 +304,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		scpi_dmm_get_meas_agilent,
 		ARRAY_AND_SIZE(devopts_generic),
 		0, 0, 0, 0, FALSE,
+		NULL, NULL, NULL,
 		NULL, NULL, NULL,
 	},
 	{
@@ -296,6 +315,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		/* 34401A: typ. 1020ms for AC readings (default is 1000ms). */
 		1500 * 1000, 0, 0, 0, FALSE,
 		NULL, NULL, NULL,
+		NULL, NULL, NULL,
 	},
 	{
 		"Keysight", "34465A",
@@ -304,30 +324,33 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		ARRAY_AND_SIZE(devopts_generic_range),
 		0, 0, 10 * 1000, 0, FALSE,
 		scpi_dmm_get_range_text, scpi_dmm_set_range_from_text, NULL,
+		NULL, NULL, NULL,
 	},
 	{
 		"OWON", "XDM1041",
 		1, 5, cmdset_owon, ARRAY_AND_SIZE(mqopts_owon_xdm1041),
 		scpi_dmm_get_meas_gwinstek,
-		ARRAY_AND_SIZE(devopts_generic_range),
+		ARRAY_AND_SIZE(devopts_owon_range),
 		0, 0, 0, 1e9, TRUE,
 		scpi_dmm_owon_get_range_text, scpi_dmm_owon_set_range_from_text, scpi_dmm_owon_get_range_text_list,
-	},
+		scpi_dmm_owon_get_meas_rate_text, scpi_dmm_owon_set_meas_rate_from_text, scpi_dmm_owon_get_meas_rate_text_list,	},
 	{
 		"OWON", "XDM1241",
 		1, 5, cmdset_owon, ARRAY_AND_SIZE(mqopts_owon_xdm1041),
 		scpi_dmm_get_meas_gwinstek,
-		ARRAY_AND_SIZE(devopts_generic_range),
+		ARRAY_AND_SIZE(devopts_owon_range),
 		0, 0, 0, 1e9, TRUE,
 		scpi_dmm_owon_get_range_text, scpi_dmm_owon_set_range_from_text, scpi_dmm_owon_get_range_text_list,
+		scpi_dmm_owon_get_meas_rate_text, scpi_dmm_owon_set_meas_rate_from_text, scpi_dmm_owon_get_meas_rate_text_list,
 	},
 	{
 		"OWON", "XDM2041",
 		1, 5, cmdset_owon, ARRAY_AND_SIZE(mqopts_owon_xdm2041),
 		scpi_dmm_get_meas_gwinstek,
-		ARRAY_AND_SIZE(devopts_generic_range),
+		ARRAY_AND_SIZE(devopts_owon_range),
 		0, 0, 0, 1e9, TRUE,
 		scpi_dmm_owon_get_range_text, scpi_dmm_owon_set_range_from_text, scpi_dmm_owon_get_range_text_list,
+		scpi_dmm_owon_get_meas_rate_text, scpi_dmm_owon_set_meas_rate_from_text, scpi_dmm_owon_get_meas_rate_text_list,
 	},
 	{
 		"Siglent", "SDM3055",
@@ -335,6 +358,7 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		scpi_dmm_get_meas_agilent,
 		ARRAY_AND_SIZE(devopts_generic),
 		0, 0, 0, 0, FALSE,
+		NULL, NULL, NULL,
 		NULL, NULL, NULL,
 	},
 };
@@ -501,6 +525,7 @@ static int config_get(uint32_t key, GVariant **data,
 	GVariant *arr[2];
 	int ret;
 	const char *range;
+	const char *meas_rate;
 
 	(void)cg;
 
@@ -531,6 +556,14 @@ static int config_get(uint32_t key, GVariant **data,
 			return SR_ERR_NA;
 		*data = g_variant_new_string(range);
 		return SR_OK;
+	case SR_CONF_MEAS_RATE:
+		if (!devc || !devc->model->get_meas_rate_text)
+			return SR_ERR_NA;
+		meas_rate = devc->model->get_meas_rate_text(sdi);
+		if (!meas_rate || !*meas_rate)
+			return SR_ERR_NA;
+		*data = g_variant_new_string(meas_rate);
+		return SR_OK;
 	default:
 		return SR_ERR_NA;
 	}
@@ -544,6 +577,7 @@ static int config_set(uint32_t key, GVariant *data,
 	enum sr_mqflag mqflag;
 	GVariant *tuple_child;
 	const char *range;
+	const char *meas_rate;
 
 	(void)cg;
 
@@ -566,6 +600,11 @@ static int config_set(uint32_t key, GVariant *data,
 			return SR_ERR_NA;
 		range = g_variant_get_string(data, NULL);
 		return devc->model->set_range_from_text(sdi, range);
+	case SR_CONF_MEAS_RATE:
+		if (!devc || !devc->model->set_meas_rate_from_text)
+			return SR_ERR_NA;
+		meas_rate = g_variant_get_string(data, NULL);
+		return devc->model->set_meas_rate_from_text(sdi, meas_rate);
 	default:
 		return SR_ERR_NA;
 	}
@@ -609,6 +648,11 @@ static int config_list(uint32_t key, GVariant **data,
 		if (!devc || !devc->model->get_range_text_list)
 			return SR_ERR_NA;
 		*data = devc->model->get_range_text_list(sdi);
+		return SR_OK;
+	case SR_CONF_MEAS_RATE:
+		if (!devc || !devc->model->get_meas_rate_text_list)
+			return SR_ERR_NA;
+		*data = devc->model->get_meas_rate_text_list(sdi);
 		return SR_OK;
 	default:
 		(void)devc;

--- a/src/hardware/scpi-dmm/protocol.c
+++ b/src/hardware/scpi-dmm/protocol.c
@@ -53,6 +53,10 @@ static const char *owon_temp_ranges[] = {
 	"KITS90", "Pt100", NULL /* no auto here */
 };
 
+static const char *owon_rate_ranges[] = {
+		"High", "Medium", "Low", NULL /* High - F, Medium - M, Low - S */
+};
+
 SR_PRIV void scpi_dmm_cmd_delay(struct sr_scpi_dev_inst *scpi)
 {
 	if (WITH_CMD_DELAY)
@@ -560,6 +564,152 @@ SR_PRIV GVariant *scpi_dmm_owon_get_range_text_list(const struct sr_dev_inst *sd
 	list = g_variant_builder_end(&gvb);
 	return list;
 }
+
+
+SR_PRIV int scpi_dmm_owon_set_meas_rate_from_text(const struct sr_dev_inst *sdi,
+            const char *meas_rate)
+{
+	struct dev_context *devc;
+	const struct mqopt_item *mqitem;
+	const char *param;
+
+
+	if (!meas_rate || !*meas_rate)
+		return SR_ERR_ARG;
+
+	devc = sdi->priv;
+
+	/* Get current measurement quantity to return appropriate ranges */
+	int ret = scpi_dmm_get_mq(sdi, NULL, NULL, NULL, &mqitem);
+	if (ret != SR_OK) {
+		return ret;
+	}
+
+	if (!mqitem || !mqitem->scpi_func_setup)
+		return SR_ERR_ARG;
+
+	/* Check if current mode has no measurements rate support */
+	if (!(mqitem->drv_flags & FLAG_HAS_MEAS_RATE)) {
+		return SR_ERR_NA;
+	}
+
+	/* Map textual meas_rate to single-letter code expected by device */
+	if (g_ascii_strcasecmp(meas_rate, owon_rate_ranges[0]) == 0)
+		param = "F";
+	else if (g_ascii_strcasecmp(meas_rate, owon_rate_ranges[1]) == 0)
+		param = "M";
+	else if (g_ascii_strcasecmp(meas_rate, owon_rate_ranges[2]) == 0)
+		param = "S";
+	else
+		return SR_ERR_ARG;
+
+	/* Send setup command */
+	scpi_dmm_cmd_delay(sdi->conn);
+	ret = sr_scpi_cmd(sdi, devc->cmdset, 0, NULL,
+			  DMM_CMD_SETUP_MEAS_RATE, param);
+	if (ret != SR_OK)
+		return ret;
+
+	if (mqitem->drv_flags & FLAG_CONF_DELAY)
+		g_usleep(devc->model->conf_delay_us);
+
+	return SR_OK;
+}
+
+
+/*
+ * Retrieves the current measurement rate from the OWON device and maps it
+ * to a human-readable text string ("High", "Medium", "Low").
+ */
+SR_PRIV const char *scpi_dmm_owon_get_meas_rate_text(const struct sr_dev_inst *sdi)
+{
+	struct dev_context *devc;
+	int ret;
+	const struct mqopt_item *item;
+	char *response = NULL;
+	char ch;
+
+	if (!sdi)
+		return NULL;
+	devc = sdi->priv;
+	if (!devc)
+		return NULL;
+
+	/* Ensure we have current measurement item */
+	ret = scpi_dmm_get_mq(sdi, NULL, NULL, NULL, &item);
+	if (ret != SR_OK)
+		return NULL;
+	if (!item || !item->scpi_func_setup)
+		return NULL;
+	if (!(item->drv_flags & FLAG_HAS_MEAS_RATE))
+		return NULL;
+
+	/* Query device for speed */
+	scpi_dmm_cmd_delay(sdi->conn);
+	ret = sr_scpi_cmd(sdi, devc->cmdset, 0, NULL,
+		DMM_CMD_QUERY_MEAS_RATE, item->scpi_func_setup);
+	if (ret != SR_OK)
+		return NULL;
+
+	ret = sr_scpi_get_string(sdi->conn, NULL, &response);
+	if (ret != SR_OK || !response) {
+		g_free(response);
+		return NULL;
+	}
+	g_strstrip(response);
+
+	if (!*response) {
+		g_free(response);
+		return NULL;
+	}
+
+	/* use single uppercase character as returned text */
+	ch = g_ascii_toupper(*response);
+	g_free(response);
+
+	/* Map to human-readable text */
+	if (ch == 'F')
+		return owon_rate_ranges[0];
+	if (ch == 'M')
+		return owon_rate_ranges[1];
+	if (ch == 'S')
+		return owon_rate_ranges[2];
+	return NULL;
+}
+
+
+SR_PRIV GVariant *scpi_dmm_owon_get_meas_rate_text_list(const struct sr_dev_inst *sdi)
+{
+	GVariantBuilder gvb;
+	GVariant *list;
+	const struct mqopt_item *mqitem;
+
+	/* Explicitly use string array type, otherwise empty array won't be typed */
+	g_variant_builder_init(&gvb, G_VARIANT_TYPE_STRING_ARRAY);
+
+	/* Get current measurement quantity to return appropriate ranges */
+	int ret = scpi_dmm_get_mq(sdi, NULL, NULL, NULL, &mqitem);
+	if (ret != SR_OK) {
+		/* Return empty list if we can't determine current mode */
+		list = g_variant_builder_end(&gvb);
+		return list;
+	}
+
+	/* Check if current mode has no measurements rate support */
+	if (mqitem && !(mqitem->drv_flags & FLAG_HAS_MEAS_RATE)) {
+		/* Return empty list for modes that don't support measurements rate */
+		list = g_variant_builder_end(&gvb);
+		return list;
+	}
+
+	for (int i = 0; owon_rate_ranges[i] != NULL; i++) {
+		g_variant_builder_add(&gvb, "s", owon_rate_ranges[i]);
+	}
+
+	list = g_variant_builder_end(&gvb);
+	return list;
+}
+
 
 SR_PRIV int scpi_dmm_get_meas_agilent(const struct sr_dev_inst *sdi, size_t ch)
 {

--- a/src/hardware/scpi-dmm/protocol.h
+++ b/src/hardware/scpi-dmm/protocol.h
@@ -45,6 +45,8 @@ enum scpi_dmm_cmdcode {
 	DMM_CMD_QUERY_RANGE,
 	DMM_CMD_SETUP_RANGE_AUTO,
 	DMM_CMD_SETUP_RANGE,
+	DMM_CMD_SETUP_MEAS_RATE,
+	DMM_CMD_QUERY_MEAS_RATE,
 };
 
 struct mqopt_item {
@@ -60,6 +62,7 @@ struct mqopt_item {
 #define FLAG_NO_RANGE	(1 << 0)
 #define FLAG_CONF_DELAY	(1 << 1)
 #define FLAG_MEAS_DELAY	(1 << 2)
+#define FLAG_HAS_MEAS_RATE	(1 << 3)
 
 struct scpi_dmm_model {
 	const char *vendor;
@@ -81,6 +84,10 @@ struct scpi_dmm_model {
 	int (*set_range_from_text)(const struct sr_dev_inst *sdi,
 		const char *range);
 	GVariant *(*get_range_text_list)(const struct sr_dev_inst *sdi);
+	const char *(*get_meas_rate_text)(const struct sr_dev_inst *sdi);
+	int (*set_meas_rate_from_text)(const struct sr_dev_inst *sdi,
+		const char *speed);
+	GVariant *(*get_meas_rate_text_list)(const struct sr_dev_inst *sdi);
 };
 
 struct dev_context {
@@ -126,5 +133,10 @@ SR_PRIV GVariant *scpi_dmm_owon_get_range_text_list(const struct sr_dev_inst *sd
 SR_PRIV int scpi_dmm_get_meas_agilent(const struct sr_dev_inst *sdi, size_t ch);
 SR_PRIV int scpi_dmm_get_meas_gwinstek(const struct sr_dev_inst *sdi, size_t ch);
 SR_PRIV int scpi_dmm_receive_data(int fd, int revents, void *cb_data);
+
+SR_PRIV const char *scpi_dmm_owon_get_meas_rate_text(const struct sr_dev_inst *sdi);
+SR_PRIV int scpi_dmm_owon_set_meas_rate_from_text(const struct sr_dev_inst *sdi,
+	const char *range);
+SR_PRIV GVariant *scpi_dmm_owon_get_meas_rate_text_list(const struct sr_dev_inst *sdi);
 
 #endif

--- a/src/hwdriver.c
+++ b/src/hwdriver.c
@@ -265,6 +265,10 @@ static struct sr_key_info sr_key_info_config[] = {
 
 	{SR_CONF_GATE_TIME, SR_T_RATIONAL_PERIOD, "gate_time",
 		"Gate time", NULL},
+
+	{SR_CONF_MEAS_RATE, SR_T_STRING, "meas_rate",
+		"Measurements rate", NULL},
+
 	ALL_ZERO
 };
 


### PR DESCRIPTION
This pull request adds support for configuring and querying the measurement rate for OWON XDM series digital multimeters (DMMs) in the SCPI hardware driver. The changes introduce a new configuration key, update the relevant device models, and implement the necessary protocol logic to set, get, and list supported measurement rates ("High", "Medium", "Low") for applicable measurement modes.